### PR TITLE
Added border and hover effect to scroll icons

### DIFF
--- a/src/css/rmus.css
+++ b/src/css/rmus.css
@@ -218,7 +218,12 @@ div#userscriptOptionsOverlay {
     font-size: 18px !important;
     color: #19A1EC;
 }
-#icon_miscellaneous_buttonScrollDown, #icon_miscellaneous_buttonScrollUp{
+#icon_miscellaneous_buttonScrollDown, #icon_miscellaneous_buttonScrollUp {
     float: right;
     cursor: pointer;
+    border: 1px solid #E9E9E9;
+}
+
+#icon_miscellaneous_buttonScrollDown:hover, #icon_miscellaneous_buttonScrollUp:hover {
+    color: #FFB400;
 }


### PR DESCRIPTION
Zwar nur ne Kleinigkeit aber ich hab die Pfeile zum hoch- bzw. runterscrollen mal an die Pagination angepasst.
![arrow_down_new](https://cloud.githubusercontent.com/assets/5990297/3481727/219d7b2a-0376-11e4-9167-7494633b3eaa.png)
![arrow_down_new_hover](https://cloud.githubusercontent.com/assets/5990297/3481729/271239d8-0376-11e4-8267-52e661d4f3f0.png)
Mir gefällts so irgendwie besser, weils einheitlicher aussieht. So ziemlich alles auf RM hat ja dieses orangenen Hover Effekt.
