### PR TITLE
ADD: Dynamic Content-Height

### DIFF
--- a/src/css/rmus.css
+++ b/src/css/rmus.css
@@ -72,7 +72,6 @@ div#userscriptOptionsOverlay {
 }
 #userscriptOptions .rmus-options-content {
     overflow-y: scroll;
-    height: 400px;
 }
 #userscriptOptions .rmus-options-content table {
     border: none;

--- a/src/lib/Options.class.js
+++ b/src/lib/Options.class.js
@@ -142,6 +142,12 @@ function Options($) {
             // Im-/Export ausblenden
             $('div#rmus-options-imexport').hide();
             $('div#userscriptOptions').fadeIn(250);
+
+            // Dynamische Content-Höhe
+            $(window).ready(function() {
+                var height =  $(window).height()-250; $('div#userscriptOptions div.rmus-options-content').height(height);
+                $(window).resize(function(){var height =  $(window).height()-250; $('div#userscriptOptions div.rmus-options-content').height(height);});
+            });
         });
     };
 


### PR DESCRIPTION
Damit das Optionen-Fenster für alle Desktop-Auflösungen zufriedenstellend angezeigt wird, wird die Content-Höhe auf Basis der Browser-Höhe beim rendern der Seite definiert oder beim resizen des Browser-Fensters.
