### PR TITLE
BUGFIX: fixed height of youtube vids in spoilers

### DIFF
--- a/src/lib/Miscellaneous.class.js
+++ b/src/lib/Miscellaneous.class.js
@@ -81,7 +81,8 @@ function Miscellaneous($, _content) {
         // fixt den verzerrten YouTube Player im Forum
         if(siteLocation.getLocation("forums")) {
             $(".forum_ed_youtube embed").each(function() {
-                $(this).css("height", $(this).width() * (9 / 16) + "px");
+                $(this).css("height", $(this).parent().parent().width() * (9 / 16) + "px");
+                $(this).parent().css("height", $(this).parent().parent().width() * (9 / 16) + "px");
             });
         }
 


### PR DESCRIPTION
Titel sagt ja im Prinzip alles. Allerdings ist der Fehler jetzt nur im Forum behoben. Können noch iwo anders youtube Videos in Spoilern auftauchen?